### PR TITLE
[chore] 프로젝트 패키지/폴더 구조 정리 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Morofrontend">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Morofrontend">

--- a/app/src/main/java/com/solux/moro/core/designsystem/component/bottomAppBar.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/component/bottomAppBar.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.core.designsystem.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.solux.moro.R
+import com.solux.moro.ui.profile.component.toPxDp
+import com.solux.moro.ui.profile.component.toPxSp
 
 @Composable
 fun BottomBar() {
@@ -208,5 +210,5 @@ fun BottomBar() {
 )
 @Composable
 fun BottomBarPreview(){
-    com.solux.moro.components.BottomBar()
+    BottomBar()
 }

--- a/app/src/main/java/com/solux/moro/core/designsystem/component/followUserItem.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/component/followUserItem.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.core.designsystem.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/solux/moro/core/designsystem/component/top/TopAppBar2.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/component/top/TopAppBar2.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components.top
+package com.solux.moro.core.designsystem.component.top
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -18,8 +18,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp

--- a/app/src/main/java/com/solux/moro/core/designsystem/component/top/TopAppBar_Back.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/component/top/TopAppBar_Back.kt
@@ -1,13 +1,11 @@
-package com.solux.moro.components.top
+package com.solux.moro.core.designsystem.component.top
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,13 +18,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.solux.moro.R
-import com.solux.moro.components.top.figmaDp
-import java.time.format.TextStyle
 
 private const val TARGET_SCALE = 2.88f
 

--- a/app/src/main/java/com/solux/moro/core/designsystem/component/topAppBar.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/component/topAppBar.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.core.designsystem.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.solux.moro.R
+import com.solux.moro.ui.profile.component.toPxDp
+import com.solux.moro.ui.profile.component.toPxSp
 
 const val PIXEL_DENSITY = 2.625f
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,5 +88,5 @@ fun TopBar() {
 @Preview (device = Devices.PIXEL_4A)
 @Composable
 fun TopBarPreview(){
-    com.solux.moro.components.TopBar()
+    TopBar()
 }

--- a/app/src/main/java/com/solux/moro/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.ui.theme
+package com.solux.moro.core.designsystem.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/solux/moro/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/theme/Theme.kt
@@ -1,6 +1,5 @@
-package com.solux.moro.ui.theme
+package com.solux.moro.core.designsystem.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/solux/moro/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.ui.theme
+package com.solux.moro.core.designsystem.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/solux/moro/core/navigation/Route.kt
+++ b/app/src/main/java/com/solux/moro/core/navigation/Route.kt
@@ -1,0 +1,27 @@
+package com.solux.moro.core.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface Route
+
+sealed interface MainTabRoute : Route
+
+//@Serializable
+//data object Home : MainTabRoute
+//
+//@Serializable
+//data object Pay : MainTabRoute
+//
+//@Serializable
+//data object Order : MainTabRoute
+//
+//@Serializable
+//data object Shop : MainTabRoute
+//
+//@Serializable
+//data object Other : MainTabRoute
+//
+//@Serializable
+//data class MyMenu(
+//    val menuId: Long
+//) : Route

--- a/app/src/main/java/com/solux/moro/core/state/UiState.kt
+++ b/app/src/main/java/com/solux/moro/core/state/UiState.kt
@@ -1,0 +1,17 @@
+package com.solux.moro.core.state
+
+sealed interface UiState<out T> {
+    data object Empty : UiState<Nothing>
+
+    data object Loading : UiState<Nothing>
+
+    data class Success<out T>(
+        val data: T
+    ) : UiState<T>
+
+    data class Failure(
+        val message: String
+    ) : UiState<Nothing>
+
+    data object Init : UiState<Nothing>
+}

--- a/app/src/main/java/com/solux/moro/core/util/IntExt.kt
+++ b/app/src/main/java/com/solux/moro/core/util/IntExt.kt
@@ -1,3 +1,0 @@
-package com.solux.moro.core.util
-
-fun Int.toStringWithFormat(): String = java.text.DecimalFormat("#,###").format(this)

--- a/app/src/main/java/com/solux/moro/core/util/IntExt.kt
+++ b/app/src/main/java/com/solux/moro/core/util/IntExt.kt
@@ -1,0 +1,3 @@
+package com.solux.moro.core.util
+
+fun Int.toStringWithFormat(): String = java.text.DecimalFormat("#,###").format(this)

--- a/app/src/main/java/com/solux/moro/core/util/ModifierExt.kt
+++ b/app/src/main/java/com/solux/moro/core/util/ModifierExt.kt
@@ -27,48 +27,5 @@ inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier
         }
     }
 
-fun Modifier.dropShadow(
-    shape: Shape,
-    color: Color = Color.Black.copy(0.25f),
-    blur: Dp = 4.dp,
-    offsetY: Dp = 4.dp,
-    offsetX: Dp = 0.dp,
-    spread: Dp = 0.dp
-) = this.drawBehind {
-    val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
-    val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
 
-    val paint = Paint().apply {
-        this.color = color
-    }
 
-    if (blur.toPx() > 0) {
-        paint.asFrameworkPaint().apply {
-            maskFilter = BlurMaskFilter(blur.toPx(), BlurMaskFilter.Blur.NORMAL)
-        }
-    }
-
-    drawIntoCanvas { canvas ->
-        canvas.save()
-        canvas.translate(offsetX.toPx(), offsetY.toPx())
-        canvas.drawOutline(shadowOutline, paint)
-        canvas.restore()
-    }
-}
-
-fun Modifier.bottomBorder(
-    strokeWidth: Dp,
-    color: Color
-): Modifier =
-    this.drawBehind {
-        val strokeWidthPx = strokeWidth.toPx()
-        val width = size.width
-        val height = size.height - strokeWidthPx / 2
-
-        drawLine(
-            color = color,
-            start = Offset(x = 0f, y = height),
-            end = Offset(x = width, y = height),
-            strokeWidth = strokeWidthPx
-        )
-    }

--- a/app/src/main/java/com/solux/moro/core/util/ModifierExt.kt
+++ b/app/src/main/java/com/solux/moro/core/util/ModifierExt.kt
@@ -1,0 +1,74 @@
+package com.solux.moro.core.util
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier =
+    composed {
+        clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() }
+        ) {
+            onClick()
+        }
+    }
+
+fun Modifier.dropShadow(
+    shape: Shape,
+    color: Color = Color.Black.copy(0.25f),
+    blur: Dp = 4.dp,
+    offsetY: Dp = 4.dp,
+    offsetX: Dp = 0.dp,
+    spread: Dp = 0.dp
+) = this.drawBehind {
+    val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
+    val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
+
+    val paint = Paint().apply {
+        this.color = color
+    }
+
+    if (blur.toPx() > 0) {
+        paint.asFrameworkPaint().apply {
+            maskFilter = BlurMaskFilter(blur.toPx(), BlurMaskFilter.Blur.NORMAL)
+        }
+    }
+
+    drawIntoCanvas { canvas ->
+        canvas.save()
+        canvas.translate(offsetX.toPx(), offsetY.toPx())
+        canvas.drawOutline(shadowOutline, paint)
+        canvas.restore()
+    }
+}
+
+fun Modifier.bottomBorder(
+    strokeWidth: Dp,
+    color: Color
+): Modifier =
+    this.drawBehind {
+        val strokeWidthPx = strokeWidth.toPx()
+        val width = size.width
+        val height = size.height - strokeWidthPx / 2
+
+        drawLine(
+            color = color,
+            start = Offset(x = 0f, y = height),
+            end = Offset(x = width, y = height),
+            strokeWidth = strokeWidthPx
+        )
+    }

--- a/app/src/main/java/com/solux/moro/core/util/UiStateExt.kt
+++ b/app/src/main/java/com/solux/moro/core/util/UiStateExt.kt
@@ -1,0 +1,9 @@
+package com.solux.moro.core.util
+
+import com.solux.moro.core.state.UiState
+
+inline fun <T> UiState<T>.onSuccess(block: (T) -> Unit) {
+    if (this is UiState.Success) {
+        block(data)
+    }
+}

--- a/app/src/main/java/com/solux/moro/ui/ColorMapScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/ColorMapScreen.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.screens
+package com.solux.moro.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -25,11 +25,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.top.TopBarBack
-import com.solux.moro.components.top.figmaDp
-import java.time.format.TextStyle
-import androidx.compose.ui.draw.drawWithCache
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.top.TopBarBack
+import com.solux.moro.core.designsystem.component.top.figmaDp
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons

--- a/app/src/main/java/com/solux/moro/ui/FollowScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/FollowScreen.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.screens
+package com.solux.moro.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -15,12 +15,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.Feed
-import com.solux.moro.components.TopBar
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.TopBar
 
 @Composable
-fun HomeScreen(){
+fun FollowScreen(){
     Scaffold(
         bottomBar = { BottomBar() },
         topBar = { TopBar() }
@@ -37,16 +36,14 @@ fun HomeScreen(){
             verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
             horizontalAlignment = Alignment.Start,
         ) {//홈 화면
-            Column() {
-                Feed()
-                Feed()
-            }
+
         }
     }
 }
+
 @Preview(
-    device = Devices.PIXEL_4A)
+    device = Devices.PIXEL_4)
 @Composable
-fun HomeScreenPreview(){
-    HomeScreen()
+fun FollowScreenPreview(){
+    FollowScreen()
 }

--- a/app/src/main/java/com/solux/moro/ui/MenuScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/MenuScreen.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.screens
+package com.solux.moro.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -32,10 +32,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.top.TopBarBack
-import com.solux.moro.components.top.figmaDp
-import java.time.format.TextStyle
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.top.TopBarBack
+import com.solux.moro.core.designsystem.component.top.figmaDp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon

--- a/app/src/main/java/com/solux/moro/ui/MyMissionScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/MyMissionScreen.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.screens
+package com.solux.moro.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -20,15 +20,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.solux.moro.R
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.top.TopBarBack
-import com.solux.moro.components.top.figmaDp
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.top.TopBarBack
+import com.solux.moro.core.designsystem.component.top.figmaDp
 
 @Composable
 fun MyMissionScreen() {

--- a/app/src/main/java/com/solux/moro/ui/SelectedColorScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/SelectedColorScreen.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.screens
+package com.solux.moro.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -25,11 +25,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.top.TopBar2
-import com.solux.moro.components.top.TopBarBack
-import com.solux.moro.components.top.figmaDp
-import java.time.format.TextStyle
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.top.TopBarBack
+import com.solux.moro.core.designsystem.component.top.figmaDp
 
 @Composable
 fun SelectedColorScreen() {

--- a/app/src/main/java/com/solux/moro/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/home/HomeScreen.kt
@@ -1,11 +1,9 @@
-package com.solux.moro.screens
+package com.solux.moro.ui.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -17,13 +15,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.Captures
-import com.solux.moro.components.Profile
-import com.solux.moro.components.TopBar
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.ui.home.component.Feed
+import com.solux.moro.core.designsystem.component.TopBar
 
 @Composable
-fun ProfileScreen(){
+fun HomeScreen(){
     Scaffold(
         bottomBar = { BottomBar() },
         topBar = { TopBar() }
@@ -31,25 +28,18 @@ fun ProfileScreen(){
         val scrollState = rememberScrollState()
         Column(
             Modifier
+                //.height((2340/PIXEL_4A_DENSITY).dp)
+                //.width((1080/PIXEL_4A_DENSITY).dp)
                 .fillMaxWidth()
                 .background(color = Color(0xFF121212))
                 .padding(innerPadding)
                 .verticalScroll(scrollState),
             verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
             horizontalAlignment = Alignment.Start,
-        ) {
-            Box() {
-                Column() {
-                    Profile()
-                    Captures()
-                }
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.CenterStart)
-                        .offset(x = (-180).dp, y=(-40).dp)
-                ){
-                    //Palette()
-                }
+        ) {//홈 화면
+            Column() {
+                Feed()
+                Feed()
             }
         }
     }
@@ -57,6 +47,6 @@ fun ProfileScreen(){
 @Preview(
     device = Devices.PIXEL_4A)
 @Composable
-fun ProfileScreenPreview(){
-    ProfileScreen()
+fun HomeScreenPreview(){
+    HomeScreen()
 }

--- a/app/src/main/java/com/solux/moro/ui/home/component/feed.kt
+++ b/app/src/main/java/com/solux/moro/ui/home/component/feed.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.ui.home.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -32,6 +32,8 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.solux.moro.R
+import com.solux.moro.ui.profile.component.toPxDp
+import com.solux.moro.ui.profile.component.toPxSp
 
 
 @Composable

--- a/app/src/main/java/com/solux/moro/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/solux/moro/ui/main/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.solux.moro
+package com.solux.moro.ui.main
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -8,8 +8,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.solux.moro.screens.HomeScreen
-import com.solux.moro.ui.theme.MorofrontendTheme
+import com.solux.moro.ui.home.HomeScreen
+import com.solux.moro.core.designsystem.theme.MorofrontendTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/solux/moro/ui/mission/MissionScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/mission/MissionScreen.kt
@@ -1,6 +1,5 @@
-package com.solux.moro.screens
+package com.solux.moro.ui.mission
 
-import android.R.attr.text
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -11,12 +10,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -27,13 +24,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.solux.moro.R
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.top.TopBar2
-import com.solux.moro.components.top.figmaDp
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.core.designsystem.component.top.TopBar2
+import com.solux.moro.core.designsystem.component.top.figmaDp
 
 @Composable
 fun MissionScreen() {

--- a/app/src/main/java/com/solux/moro/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/profile/ProfileScreen.kt
@@ -1,9 +1,11 @@
-package com.solux.moro.screens
+package com.solux.moro.ui.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -15,11 +17,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.solux.moro.components.BottomBar
-import com.solux.moro.components.TopBar
+import com.solux.moro.core.designsystem.component.BottomBar
+import com.solux.moro.ui.profile.component.Profile
+import com.solux.moro.core.designsystem.component.TopBar
+import com.solux.moro.ui.profile.component.Captures
 
 @Composable
-fun FollowScreen(){
+fun ProfileScreen(){
     Scaffold(
         bottomBar = { BottomBar() },
         topBar = { TopBar() }
@@ -27,23 +31,32 @@ fun FollowScreen(){
         val scrollState = rememberScrollState()
         Column(
             Modifier
-                //.height((2340/PIXEL_4A_DENSITY).dp)
-                //.width((1080/PIXEL_4A_DENSITY).dp)
                 .fillMaxWidth()
                 .background(color = Color(0xFF121212))
                 .padding(innerPadding)
                 .verticalScroll(scrollState),
             verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
             horizontalAlignment = Alignment.Start,
-        ) {//홈 화면
-
+        ) {
+            Box() {
+                Column() {
+                    Profile()
+                    Captures()
+                }
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .offset(x = (-180).dp, y=(-40).dp)
+                ){
+                    //Palette()
+                }
+            }
         }
     }
 }
-
 @Preview(
-    device = Devices.PIXEL_4)
+    device = Devices.PIXEL_4A)
 @Composable
-fun FollowScreenPreview(){
-    FollowScreen()
+fun ProfileScreenPreview(){
+    ProfileScreen()
 }

--- a/app/src/main/java/com/solux/moro/ui/profile/component/captures.kt
+++ b/app/src/main/java/com/solux/moro/ui/profile/component/captures.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.ui.profile.component
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
@@ -30,7 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Composable
 fun Captures(){
     Column(
-        modifier = Modifier
+        modifier = Modifier.Companion
             .width(1080.toPxDp)
             .height(1091.65552.toPxDp)
             .padding(start = 46.08.toPxDp, end = 46.08.toPxDp),

--- a/app/src/main/java/com/solux/moro/ui/profile/component/palette.kt
+++ b/app/src/main/java/com/solux/moro/ui/profile/component/palette.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.ui.profile.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,7 +26,7 @@ fun Palette() {
         contentAlignment = Alignment.Center
     ) {
         Box(
-            modifier = Modifier
+            modifier = Modifier.Companion
                 .size(478.07999.toPxDp)
                 .clip(CircleShape)
                 .background(Color(0xFF8EEAF4)),

--- a/app/src/main/java/com/solux/moro/ui/profile/component/profile.kt
+++ b/app/src/main/java/com/solux/moro/ui/profile/component/profile.kt
@@ -1,4 +1,4 @@
-package com.solux.moro.components
+package com.solux.moro.ui.profile.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.solux.moro.R
+import com.solux.moro.core.designsystem.component.PIXEL_DENSITY
 
 val Number.toPxDp: Dp get() = (this.toDouble()/ PIXEL_DENSITY).dp
 val Number.toPxSp: TextUnit get() = (this.toDouble() / PIXEL_DENSITY).sp


### PR DESCRIPTION
## 📌연관 이슈
- closed #15 

## 📝작업 내용
- 프로젝트 폴더 구조를 정리하고, 앞으로 개발하실 때 파일을 어디에 두면 되는 규칙을 명확하게 만들었습니다.
- 또한 ui 개발 시 자주 쓰게 될 공용 util 확장 함수들을 core/util 에 추가해두었습니다.

- core/data/ui 3가지 큰 축으로 분리했습니다.
   - 공통 컴포넌트는 DesignSystem 아래,
   - 특정 스크린에서만 쓰는 컴포넌트는 해당 스크린 아래 component 폴더에 둡니다.
   - 추후 API 등을 붙이기 위한 data 하위 구조를 미리 생성해두었습니다.

- util > 리플 없는 클릭, UiState 성공 처리 함수를 추가했습니다.


--------------
‼️ core > 앱 전역에서 공용으로 쓰는 애들 ‼️
   - core/designsystem/
      - component/ : 여러 화면에서 재사용되는 공통 ui 컴포넌트
      - theme/ : 컬러, 타이포 등 테마 및 디자인
   - core/navigation/
      - Route 등 화면 라우팅/네비게이션 관련 정의
   - core/state/
      - UiState 같은 화면 상태 표현 (로딩/성공/실패 등)
   - core/util/
      - 프로젝트 전반에서 재사용 가능한 확장 함수/유틸리티

‼️ data > 데이터 호출용 폴더 (추후 사용 예정) ‼️
   - data/service/ : Retrofit API interface 등 
   - data/datasource/ : 실제 데이터를 가져오는 로직
   - data/repository/ : UI/ViewModel이 접근하는 진입점
   - data/dto/ : 네트워크 응답/요청 DTO
   - data/model/ : 앱에서 사용하는 도메인 모델(필요 시)
   - data/mapper/ : dto -> model 변환 등 매핑 로직
   - data/network/ : Retrofit/OkHttp 설정 등

‼️ ui > 화면 단위: Screen + 그 화면 전용 컴포넌트 ‼️
   - ui/home/, ui/mission/, ui/profile/ … 처럼 기능/화면 단위로 묶기
   - 화면 파일: HomeScreen.kt, MissionScreen.kt 등
   - 해당 화면에서만 쓰는 컴포넌트: ui/home/component/ 처럼 screen 하위에 component 폴더를 만들고 위치

-----------------

‼️util 함수 설명 (core/util) ‼️
- Modifier.noRippleClickable { }
   - Compose의 clickable을 쓰되, 클릭 리플(물결 효과) 없이 눌리게 합니다.
- UiState<T>.onSuccess { }
   - UiState가 Success일 때만 안전하게 data를 꺼내서 처리합니다.


## 📷스크린샷
  
## 💬리뷰어 요구사항
<img width="368" height="459" alt="image" src="https://github.com/user-attachments/assets/2be36b73-f990-42e3-aeda-fb717912a397" />

<컴포넌트 정리 기준 관련 안내>

정확히 어느 스크린/플로우에 속하는지 명확하게 판단 가능한 컴포넌트들은 제가 선별해서 정리해두었습니다!
다만, 현재 기준으로 스크린 소속이 불분명한 컴포넌트들은 임의로 분리하지 않고, 기존과 동일하게 공통 컴포넌트 폴더(core/designsystem/component)에 그대로 유지했습니다.

컴포넌트 만드신 분이 판단하셔서 어느 쪽에 넣을지 선택해주세요!

⸻

<스크린 정리 관련 안내>

하단에 남아 있는 일부 스크린 파일들 또한 제가 판단하기에 메인 네비게이션 플로우 기준으로 어떤 기능 묶음에 속하는지 명확하지 않아 이번 pr에서는 이동하지 않고 그대로 두었습니다.

해당 스크린 만드는 분이 판단하셔서,
- 해당 플로우에 맞게 기존 폴더로 이동하거나
- 필요하다면 새로운 기능/스크린 폴더를 생성해서 정리해주시면 됩니다!!!
