### PR TITLE
[fix] Colors 구조 변경으로 ClassFormatError 해결

### DIFF
--- a/app/src/main/java/com/solux/moro/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/solux/moro/core/designsystem/theme/Color.kt
@@ -5,370 +5,220 @@ import androidx.compose.ui.graphics.Color
 
 /**
  * Basic
+ * - 앱 전반에서 자주 쓰는 컬러만 `Colors`에 넣습니다.
+ *
+ * 사용 예:
+ * - MoroTheme.Colors.background
  */
 
+// Grays
 val Gray10 = Color(0xFFF2F2F2)
 val Gray15 = Color(0xFFEEEEEE)
 val Gray20 = Color(0xFFD5D5D5)
 val Gray30 = Color(0xFFBDBDBD)
 val Gray40 = Color(0xFFA5A5A5)
 
+// Background / Text
 val Background = Color(0xFF121212)
-val FontColor = Color(0xF2F2F2)
-
-/**
- * Palette
- * Naming: <Palette><Hue><Level>
- */
-
-val PastelPurple100 = Color(0xFFF5D8E0)
-val PastelPurple200 = Color(0xFFEEB6C6)
-val PastelPurple300 = Color(0xFFE895AB)
-val PastelPurple400 = Color(0xFFDF7DA8)
-val PastelPurple500 = Color(0xFFCD5F80)
-val PastelPurple600 = Color(0xFFB34166)
-
-val PastelOrange100 = Color(0xFFF7E6BA)
-val PastelOrange200 = Color(0xFFF3D6A5)
-val PastelOrange300 = Color(0xFFEEBB84)
-val PastelOrange400 = Color(0xFFE99F65)
-val PastelOrange500 = Color(0xFFD1814B)
-val PastelOrange600 = Color(0xFFB76B40)
-
-val PastelYellow100 = Color(0xFFFCF9CA)
-val PastelYellow200 = Color(0xFFFAF5A8)
-val PastelYellow300 = Color(0xFFF9F189)
-val PastelYellow400 = Color(0xFFF8EE74)
-val PastelYellow500 = Color(0xFFF1D95B)
-val PastelYellow600 = Color(0xFFEBC251)
-
-val PastelGreen100 = Color(0xFFD8EFC5)
-val PastelGreen200 = Color(0xFFBFE3AA)
-val PastelGreen300 = Color(0xFFA8D98F)
-val PastelGreen400 = Color(0xFF92CD76)
-val PastelGreen500 = Color(0xFF7EC35E)
-val PastelGreen600 = Color(0xFF64A743)
-
-val PastelCyan100 = Color(0xFFDEEFFD)
-val PastelCyan200 = Color(0xFFC3E4FC)
-val PastelCyan300 = Color(0xFFA9D7FB)
-val PastelCyan400 = Color(0xFF91CAFA)
-val PastelCyan500 = Color(0xFF7CBDF9)
-val PastelCyan600 = Color(0xFF5C97C7)
-
-val PastelIndigo100 = Color(0xFFE7E6F8)
-val PastelIndigo200 = Color(0xFFD2C0D6)
-val PastelIndigo300 = Color(0xFFC5A6DA)
-val PastelIndigo400 = Color(0xFFAF84CC)
-val PastelIndigo500 = Color(0xFF905DB0)
-val PastelIndigo600 = Color(0xFF744493)
-
-val PastelGray100 = Color(0xFFF5F5F5)
-val PastelGray200 = Color(0xFFE0E0E0)
-val PastelGray300 = Color(0xFFCCCCCC)
-val PastelGray400 = Color(0xFFB3B3B3)
-val PastelGray500 = Color(0xFF999999)
-val PastelGray600 = Color(0xFF7F7F7F)
-
-val PastelBlack = Color(0xFF000000)
-val PastelWhite = Color(0xFFFFFFFF)
-val PastelWhite100 = Color(0xFFFAF9F6)
-val PastelGray2300 = Color(0xFFDDDDDD)
-val PastelGray2400 = Color(0xFFC0C0C0)
-val PastelGray2600 = Color(0xFF444444)
-
-val VividRed100 = Color(0xFFDE3323)
-val VividRed200 = Color(0xFFB1271A)
-val VividRed300 = Color(0xFF851A11)
-val VividRed400 = Color(0xFF580E08)
-val VividRed500 = Color(0xFFE26F2E)
-val VividRed600 = Color(0xFFB55923)
-
-val VividYellow100 = Color(0xFF874218)
-val VividYellow200 = Color(0xFF5A2C0D)
-val VividYellow300 = Color(0xFFFCFE57)
-val VividYellow400 = Color(0xFFC9CB44)
-val VividYellow500 = Color(0xFF979831)
-val VividYellow600 = Color(0xFF65661E)
-
-val VividGreen100 = Color(0xFF6AC83E)
-val VividGreen200 = Color(0xFF4E962C)
-val VividGreen300 = Color(0xFF32641A)
-val VividGreen400 = Color(0xFF163209)
-val VividGreen500 = Color(0xFF4767F5)
-val VividGreen600 = Color(0xFF2E4C93)
-
-val VividIndigo100 = Color(0xFF1D3362)
-val VividIndigo200 = Color(0xFF0B1931)
-val VividIndigo300 = Color(0xFF8C25F5)
-val VividIndigo400 = Color(0xFF6A1BC3)
-val VividIndigo500 = Color(0xFF481092)
-val VividIndigo600 = Color(0xFF2F0761)
-
-val VividPurple100 = Color(0xFFE04997)
-val VividPurple200 = Color(0xFFB33A78)
-val VividPurple300 = Color(0xFF862B5A)
-val VividPurple400 = Color(0xFF591D3C)
-val VividPurple500 = Color(0xFF905636)
-val VividPurple600 = Color(0xFF6D3F27)
-
-val VividCyan100 = Color(0xFF4C2A19)
-val VividCyan200 = Color(0xFF26150C)
-val VividCyan300 = Color(0xFF6197C7)
-val VividCyan400 = Color(0xFF487295)
-val VividCyan500 = Color(0xFF304C64)
-val VividCyan600 = Color(0xFF172632)
-
-val VividYellow2100 = Color(0xFF979846)
-val VividYellow2200 = Color(0xFF727334)
-val VividYellow2300 = Color(0xFF4C4D23)
-val VividYellow2400 = Color(0xFF252611)
-val VividYellow2500 = Color(0xFF78C9CB)
-val VividYellow2600 = Color(0xFF599798)
-
-val VividGray100 = Color(0xFF3B6565)
-val VividGray200 = Color(0xFF1C3233)
-val VividGray300 = Color(0xFF242424)
-val VividGray400 = Color(0xFFF7F4F4)
-val VividGray500 = Color(0xFF999999)
-val VividGray600 = Color(0xFF333333)
-
-val NatureCyan100 = Color(0xFFDFF6FD)
-val NatureCyan200 = Color(0xFFCBF2FD)
-val NatureCyan300 = Color(0xFFABE9FE)
-val NatureCyan400 = Color(0xFF8EDBFE)
-val NatureCyan500 = Color(0xFF5ABAF4)
-val NatureCyan600 = Color(0xFF1985C3)
-
-val NatureCyan2100 = Color(0xFFDFF6FC)
-val NatureCyan2200 = Color(0xFFD2F2FC)
-val NatureCyan2300 = Color(0xFFA2E8FB)
-val NatureCyan2400 = Color(0xFF68D3F8)
-val NatureCyan2500 = Color(0xFF40B7E7)
-val NatureCyan2600 = Color(0xFF0D8ABB)
-
-val NatureTeal100 = Color(0xFFD7F1F2)
-val NatureTeal200 = Color(0xFFBAEBE6)
-val NatureTeal300 = Color(0xFF9EE2DB)
-val NatureTeal400 = Color(0xFF5BCEC6)
-val NatureTeal500 = Color(0xFF3BB9BF)
-val NatureTeal600 = Color(0xFF10809C)
-
-val NatureTeal2100 = Color(0xFFD2EEEC)
-val NatureTeal2200 = Color(0xFFC1E6E0)
-val NatureTeal2300 = Color(0xFF8FDBD2)
-val NatureTeal2400 = Color(0xFF6AC6BB)
-val NatureTeal2500 = Color(0xFF3FB9A5)
-val NatureTeal2600 = Color(0xFF11788A)
-
-val NatureGreen100 = Color(0xFFDBE8D6)
-val NatureGreen200 = Color(0xFFC6D9B7)
-val NatureGreen300 = Color(0xFF99BB7F)
-val NatureGreen400 = Color(0xFF699860)
-val NatureGreen500 = Color(0xFF4C7B4D)
-val NatureGreen600 = Color(0xFF3D6547)
-
-val NatureBrown100 = Color(0xFFEAE5D7)
-val NatureBrown200 = Color(0xFFE5D6BD)
-val NatureBrown300 = Color(0xFFD3C09C)
-val NatureBrown400 = Color(0xFFB4A17D)
-val NatureBrown500 = Color(0xFF978161)
-val NatureBrown600 = Color(0xFF5F4E3E)
-
-val NatureOrange100 = Color(0xFFF2DFB6)
-val NatureOrange200 = Color(0xFFF3C386)
-val NatureOrange300 = Color(0xFFF0AA58)
-val NatureOrange400 = Color(0xFFD66D44)
-val NatureOrange500 = Color(0xFFB95145)
-val NatureOrange600 = Color(0xFF884642)
-
-val NaturePurple100 = Color(0xFFF1CBB0)
-val NaturePurple200 = Color(0xFFEFB481)
-val NaturePurple300 = Color(0xFFE38373)
-val NaturePurple400 = Color(0xFFCE656C)
-val NaturePurple500 = Color(0xFF96547D)
-val NaturePurple600 = Color(0xFF7D466A)
-
+val FontColor = Color(0xFFF2F2F2)
 
 @Immutable
 data class Colors(
+    val background: Color = Background,
+    val fontColor: Color = FontColor,
+
     val gray10: Color = Gray10,
     val gray15: Color = Gray15,
     val gray20: Color = Gray20,
     val gray30: Color = Gray30,
     val gray40: Color = Gray40,
-
-    val background: Color = Background,
-    val fontColor: Color = FontColor,
-
-    val pastelpurple100: Color = PastelPurple100,
-    val pastelpurple200: Color = PastelPurple200,
-    val pastelpurple300: Color = PastelPurple300,
-    val pastelpurple400: Color = PastelPurple400,
-    val pastelpurple500: Color = PastelPurple500,
-    val pastelpurple600: Color = PastelPurple600,
-
-    val pastelorange100: Color = PastelOrange100,
-    val pastelorange200: Color = PastelOrange200,
-    val pastelorange300: Color = PastelOrange300,
-    val pastelorange400: Color = PastelOrange400,
-    val pastelorange500: Color = PastelOrange500,
-    val pastelorange600: Color = PastelOrange600,
-
-    val pastelyellow100: Color = PastelYellow100,
-    val pastelyellow200: Color = PastelYellow200,
-    val pastelyellow300: Color = PastelYellow300,
-    val pastelyellow400: Color = PastelYellow400,
-    val pastelyellow500: Color = PastelYellow500,
-    val pastelyellow600: Color = PastelYellow600,
-
-    val pastelgreen100: Color = PastelGreen100,
-    val pastelgreen200: Color = PastelGreen200,
-    val pastelgreen300: Color = PastelGreen300,
-    val pastelgreen400: Color = PastelGreen400,
-    val pastelgreen500: Color = PastelGreen500,
-    val pastelgreen600: Color = PastelGreen600,
-
-    val pastelcyan100: Color = PastelCyan100,
-    val pastelcyan200: Color = PastelCyan200,
-    val pastelcyan300: Color = PastelCyan300,
-    val pastelcyan400: Color = PastelCyan400,
-    val pastelcyan500: Color = PastelCyan500,
-    val pastelcyan600: Color = PastelCyan600,
-
-    val pastelindigo100: Color = PastelIndigo100,
-    val pastelindigo200: Color = PastelIndigo200,
-    val pastelindigo300: Color = PastelIndigo300,
-    val pastelindigo400: Color = PastelIndigo400,
-    val pastelindigo500: Color = PastelIndigo500,
-    val pastelindigo600: Color = PastelIndigo600,
-
-    val pastelgray100: Color = PastelGray100,
-    val pastelgray200: Color = PastelGray200,
-    val pastelgray300: Color = PastelGray300,
-    val pastelgray400: Color = PastelGray400,
-    val pastelgray500: Color = PastelGray500,
-    val pastelgray600: Color = PastelGray600,
-
-    val pastelblack: Color = PastelBlack,
-    val pastelwhite: Color = PastelWhite,
-    val pastelwhite100: Color = PastelWhite100,
-    val pastelgray2300: Color = PastelGray2300,
-    val pastelgray2400: Color = PastelGray2400,
-    val pastelgray2600: Color = PastelGray2600,
-
-    val vividred100: Color = VividRed100,
-    val vividred200: Color = VividRed200,
-    val vividred300: Color = VividRed300,
-    val vividred400: Color = VividRed400,
-    val vividred500: Color = VividRed500,
-    val vividred600: Color = VividRed600,
-
-    val vividyellow100: Color = VividYellow100,
-    val vividyellow200: Color = VividYellow200,
-    val vividyellow300: Color = VividYellow300,
-    val vividyellow400: Color = VividYellow400,
-    val vividyellow500: Color = VividYellow500,
-    val vividyellow600: Color = VividYellow600,
-
-    val vividgreen100: Color = VividGreen100,
-    val vividgreen200: Color = VividGreen200,
-    val vividgreen300: Color = VividGreen300,
-    val vividgreen400: Color = VividGreen400,
-    val vividgreen500: Color = VividGreen500,
-    val vividgreen600: Color = VividGreen600,
-
-    val vividindigo100: Color = VividIndigo100,
-    val vividindigo200: Color = VividIndigo200,
-    val vividindigo300: Color = VividIndigo300,
-    val vividindigo400: Color = VividIndigo400,
-    val vividindigo500: Color = VividIndigo500,
-    val vividindigo600: Color = VividIndigo600,
-
-    val vividpurple100: Color = VividPurple100,
-    val vividpurple200: Color = VividPurple200,
-    val vividpurple300: Color = VividPurple300,
-    val vividpurple400: Color = VividPurple400,
-    val vividpurple500: Color = VividPurple500,
-    val vividpurple600: Color = VividPurple600,
-
-    val vividcyan100: Color = VividCyan100,
-    val vividcyan200: Color = VividCyan200,
-    val vividcyan300: Color = VividCyan300,
-    val vividcyan400: Color = VividCyan400,
-    val vividcyan500: Color = VividCyan500,
-    val vividcyan600: Color = VividCyan600,
-
-    val vividyellow2100: Color = VividYellow2100,
-    val vividyellow2200: Color = VividYellow2200,
-    val vividyellow2300: Color = VividYellow2300,
-    val vividyellow2400: Color = VividYellow2400,
-    val vividyellow2500: Color = VividYellow2500,
-    val vividyellow2600: Color = VividYellow2600,
-
-    val vividgray100: Color = VividGray100,
-    val vividgray200: Color = VividGray200,
-    val vividgray300: Color = VividGray300,
-    val vividgray400: Color = VividGray400,
-    val vividgray500: Color = VividGray500,
-    val vividgray600: Color = VividGray600,
-
-    val naturecyan100: Color = NatureCyan100,
-    val naturecyan200: Color = NatureCyan200,
-    val naturecyan300: Color = NatureCyan300,
-    val naturecyan400: Color = NatureCyan400,
-    val naturecyan500: Color = NatureCyan500,
-    val naturecyan600: Color = NatureCyan600,
-
-    val naturecyan2100: Color = NatureCyan2100,
-    val naturecyan2200: Color = NatureCyan2200,
-    val naturecyan2300: Color = NatureCyan2300,
-    val naturecyan2400: Color = NatureCyan2400,
-    val naturecyan2500: Color = NatureCyan2500,
-    val naturecyan2600: Color = NatureCyan2600,
-
-    val natureteal100: Color = NatureTeal100,
-    val natureteal200: Color = NatureTeal200,
-    val natureteal300: Color = NatureTeal300,
-    val natureteal400: Color = NatureTeal400,
-    val natureteal500: Color = NatureTeal500,
-    val natureteal600: Color = NatureTeal600,
-
-    val natureteal2100: Color = NatureTeal2100,
-    val natureteal2200: Color = NatureTeal2200,
-    val natureteal2300: Color = NatureTeal2300,
-    val natureteal2400: Color = NatureTeal2400,
-    val natureteal2500: Color = NatureTeal2500,
-    val natureteal2600: Color = NatureTeal2600,
-
-    val naturegreen100: Color = NatureGreen100,
-    val naturegreen200: Color = NatureGreen200,
-    val naturegreen300: Color = NatureGreen300,
-    val naturegreen400: Color = NatureGreen400,
-    val naturegreen500: Color = NatureGreen500,
-    val naturegreen600: Color = NatureGreen600,
-
-    val naturebrown100: Color = NatureBrown100,
-    val naturebrown200: Color = NatureBrown200,
-    val naturebrown300: Color = NatureBrown300,
-    val naturebrown400: Color = NatureBrown400,
-    val naturebrown500: Color = NatureBrown500,
-    val naturebrown600: Color = NatureBrown600,
-
-    val natureorange100: Color = NatureOrange100,
-    val natureorange200: Color = NatureOrange200,
-    val natureorange300: Color = NatureOrange300,
-    val natureorange400: Color = NatureOrange400,
-    val natureorange500: Color = NatureOrange500,
-    val natureorange600: Color = NatureOrange600,
-
-    val naturepurple100: Color = NaturePurple100,
-    val naturepurple200: Color = NaturePurple200,
-    val naturepurple300: Color = NaturePurple300,
-    val naturepurple400: Color = NaturePurple400,
-    val naturepurple500: Color = NaturePurple500,
-    val naturepurple600: Color = NaturePurple600,
 )
 
 val defaultColors = Colors()
+
+/**
+ * Palette Tokens
+ * Naming: <Palette><Hue><Level>
+ *
+ * 사용 예:
+ * - MoroPalette.Pastel.Purple100
+ * - MoroPalette.Vivid.Red300
+ * - MoroPalette.Nature.Teal500
+ */
+object MoroPalette {
+    object Pastel {
+        val Purple100 = Color(0xFFF5D8E0)
+        val Purple200 = Color(0xFFEEB6C6)
+        val Purple300 = Color(0xFFE895AB)
+        val Purple400 = Color(0xFFDF7DA8)
+        val Purple500 = Color(0xFFCD5F80)
+        val Purple600 = Color(0xFFB34166)
+
+        val Orange100 = Color(0xFFF7E6BA)
+        val Orange200 = Color(0xFFF3D6A5)
+        val Orange300 = Color(0xFFEEBB84)
+        val Orange400 = Color(0xFFE99F65)
+        val Orange500 = Color(0xFFD1814B)
+        val Orange600 = Color(0xFFB76B40)
+
+        val Yellow100 = Color(0xFFFCF9CA)
+        val Yellow200 = Color(0xFFFAF5A8)
+        val Yellow300 = Color(0xFFF9F189)
+        val Yellow400 = Color(0xFFF8EE74)
+        val Yellow500 = Color(0xFFF1D95B)
+        val Yellow600 = Color(0xFFEBC251)
+
+        val Green100 = Color(0xFFD8EFC5)
+        val Green200 = Color(0xFFBFE3AA)
+        val Green300 = Color(0xFFA8D98F)
+        val Green400 = Color(0xFF92CD76)
+        val Green500 = Color(0xFF7EC35E)
+        val Green600 = Color(0xFF64A743)
+
+        val Cyan100 = Color(0xFFDEEFFD)
+        val Cyan200 = Color(0xFFC3E4FC)
+        val Cyan300 = Color(0xFFA9D7FB)
+        val Cyan400 = Color(0xFF91CAFA)
+        val Cyan500 = Color(0xFF7CBDF9)
+        val Cyan600 = Color(0xFF5C97C7)
+
+        val Indigo100 = Color(0xFFE7E6F8)
+        val Indigo200 = Color(0xFFD2C0D6)
+        val Indigo300 = Color(0xFFC5A6DA)
+        val Indigo400 = Color(0xFFAF84CC)
+        val Indigo500 = Color(0xFF905DB0)
+        val Indigo600 = Color(0xFF744493)
+
+        val Gray100 = Color(0xFFF5F5F5)
+        val Gray200 = Color(0xFFE0E0E0)
+        val Gray300 = Color(0xFFCCCCCC)
+        val Gray400 = Color(0xFFB3B3B3)
+        val Gray500 = Color(0xFF999999)
+        val Gray600 = Color(0xFF7F7F7F)
+
+        val Black = Color(0xFF000000)
+        val White = Color(0xFFFFFFFF)
+        val White100 = Color(0xFFFAF9F6)
+        val Gray2300 = Color(0xFFDDDDDD)
+        val Gray2400 = Color(0xFFC0C0C0)
+        val Gray2600 = Color(0xFF444444)
+    }
+
+    object Vivid {
+        val Red100 = Color(0xFFDE3323)
+        val Red200 = Color(0xFFB1271A)
+        val Red300 = Color(0xFF851A11)
+        val Red400 = Color(0xFF580E08)
+        val Red500 = Color(0xFFE26F2E)
+        val Red600 = Color(0xFFB55923)
+
+        val Yellow100 = Color(0xFF874218)
+        val Yellow200 = Color(0xFF5A2C0D)
+        val Yellow300 = Color(0xFFFCFE57)
+        val Yellow400 = Color(0xFFC9CB44)
+        val Yellow500 = Color(0xFF979831)
+        val Yellow600 = Color(0xFF65661E)
+
+        val Green100 = Color(0xFF6AC83E)
+        val Green200 = Color(0xFF4E962C)
+        val Green300 = Color(0xFF32641A)
+        val Green400 = Color(0xFF163209)
+        val Green500 = Color(0xFF4767F5)
+        val Green600 = Color(0xFF2E4C93)
+
+        val Indigo100 = Color(0xFF1D3362)
+        val Indigo200 = Color(0xFF0B1931)
+        val Indigo300 = Color(0xFF8C25F5)
+        val Indigo400 = Color(0xFF6A1BC3)
+        val Indigo500 = Color(0xFF481092)
+        val Indigo600 = Color(0xFF2F0761)
+
+        val Purple100 = Color(0xFFE04997)
+        val Purple200 = Color(0xFFB33A78)
+        val Purple300 = Color(0xFF862B5A)
+        val Purple400 = Color(0xFF591D3C)
+        val Purple500 = Color(0xFF905636)
+        val Purple600 = Color(0xFF6D3F27)
+
+        val Cyan100 = Color(0xFF4C2A19)
+        val Cyan200 = Color(0xFF26150C)
+        val Cyan300 = Color(0xFF6197C7)
+        val Cyan400 = Color(0xFF487295)
+        val Cyan500 = Color(0xFF304C64)
+        val Cyan600 = Color(0xFF172632)
+
+        val Yellow2100 = Color(0xFF979846)
+        val Yellow2200 = Color(0xFF727334)
+        val Yellow2300 = Color(0xFF4C4D23)
+        val Yellow2400 = Color(0xFF252611)
+        val Yellow2500 = Color(0xFF78C9CB)
+        val Yellow2600 = Color(0xFF599798)
+
+        val Gray100 = Color(0xFF3B6565)
+        val Gray200 = Color(0xFF1C3233)
+        val Gray300 = Color(0xFF242424)
+        val Gray400 = Color(0xFFF7F4F4)
+        val Gray500 = Color(0xFF999999)
+        val Gray600 = Color(0xFF333333)
+    }
+
+    object Nature {
+        val Cyan100 = Color(0xFFDFF6FD)
+        val Cyan200 = Color(0xFFCBF2FD)
+        val Cyan300 = Color(0xFFABE9FE)
+        val Cyan400 = Color(0xFF8EDBFE)
+        val Cyan500 = Color(0xFF5ABAF4)
+        val Cyan600 = Color(0xFF1985C3)
+
+        // (기존 네이밍 유지) 추가 세트
+        val Cyan2100 = Color(0xFFDFF6FC)
+        val Cyan2200 = Color(0xFFD2F2FC)
+        val Cyan2300 = Color(0xFFA2E8FB)
+        val Cyan2400 = Color(0xFF68D3F8)
+        val Cyan2500 = Color(0xFF40B7E7)
+        val Cyan2600 = Color(0xFF0D8ABB)
+
+        val Teal100 = Color(0xFFD7F1F2)
+        val Teal200 = Color(0xFFBAEBE6)
+        val Teal300 = Color(0xFF9EE2DB)
+        val Teal400 = Color(0xFF5BCEC6)
+        val Teal500 = Color(0xFF3BB9BF)
+        val Teal600 = Color(0xFF10809C)
+
+        val Teal2100 = Color(0xFFD2EEEC)
+        val Teal2200 = Color(0xFFC1E6E0)
+        val Teal2300 = Color(0xFF8FDBD2)
+        val Teal2400 = Color(0xFF6AC6BB)
+        val Teal2500 = Color(0xFF3FB9A5)
+        val Teal2600 = Color(0xFF11788A)
+
+        val Green100 = Color(0xFFDBE8D6)
+        val Green200 = Color(0xFFC6D9B7)
+        val Green300 = Color(0xFF99BB7F)
+        val Green400 = Color(0xFF699860)
+        val Green500 = Color(0xFF4C7B4D)
+        val Green600 = Color(0xFF3D6547)
+
+        val Brown100 = Color(0xFFEAE5D7)
+        val Brown200 = Color(0xFFE5D6BD)
+        val Brown300 = Color(0xFFD3C09C)
+        val Brown400 = Color(0xFFB4A17D)
+        val Brown500 = Color(0xFF978161)
+        val Brown600 = Color(0xFF5F4E3E)
+
+        val Orange100 = Color(0xFFF2DFB6)
+        val Orange200 = Color(0xFFF3C386)
+        val Orange300 = Color(0xFFF0AA58)
+        val Orange400 = Color(0xFFD66D44)
+        val Orange500 = Color(0xFFB95145)
+        val Orange600 = Color(0xFF884642)
+
+        val Purple100 = Color(0xFFF1CBB0)
+        val Purple200 = Color(0xFFEFB481)
+        val Purple300 = Color(0xFFE38373)
+        val Purple400 = Color(0xFFCE656C)
+        val Purple500 = Color(0xFF96547D)
+        val Purple600 = Color(0xFF7D466A)
+    }
+}
 


### PR DESCRIPTION
## 📌연관 이슈
- closed #21 

## 📝작업 내용
<문제>
- Colors data class에 팔레트 전체 컬러 토큰을 모두 생성자 파라미터로 포함하고 있어 JVM 메서드 시그니처 한도를 초과함.
- 앱 실행 및 Compose Preview 단계에서 ClassFormatError 발생

<해결>
- Colors data class에는 메인 컬러만 유지
   - background, fontColor 등
- 팔레트 컬러는 MoroPalette object로 분리하여 관리   

## 📷스크린샷
<img width="386" height="169" alt="image" src="https://github.com/user-attachments/assets/0b3e3229-05f2-4a5d-85ba-cd983b7820c6" />
<img width="282" height="198" alt="image" src="https://github.com/user-attachments/assets/bb46ef12-3054-49bc-be56-5217b9185d19" />


## 💬리뷰어 요구사항
