### PR TITLE
[feat] 미션 업로드 카메라 구현

### DIFF
--- a/app/src/main/java/com/solux/moro/ui/camera/CameraLayout.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/CameraLayout.kt
@@ -27,6 +27,7 @@ import com.solux.moro.core.util.figmaDp
 //import coil.compose.AsyncImage
 @Composable
 fun CameraLayout(
+    remainingShots: Int = 3,
     showShotCount: Boolean = false,
     onCameraClick: () -> Unit,
     showConfirmDialog: Boolean,
@@ -50,15 +51,15 @@ fun CameraLayout(
 
         if (showShotCount) {
             ShotCount(
+                count = remainingShots,
                 modifier = Modifier
-                    .align(Alignment.TopEnd)
+                    .align(Alignment.TopEnd) // 오른쪽 상단 기준
                     .padding(
                         top = figmaDp(70f) + figmaDp(12f),
                         end = figmaDp(16f)
                     )
             )
         }
-
 
         Column(modifier = Modifier.align(Alignment.BottomCenter)) {
             CameraBottomBar(
@@ -178,6 +179,7 @@ fun CameraBottomBar(
 
 @Composable
 fun ShotCount(
+    count: Int,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -191,7 +193,7 @@ fun ShotCount(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "3",
+            text = "$count",
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
             color = Color.White

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadCameraScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadCameraScreen.kt
@@ -3,7 +3,6 @@ package com.solux.moro.ui.camera
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -23,8 +22,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.solux.moro.ui.main.createImageUri
+import android.net.Uri
 import java.io.File
+
 
 @Composable
 fun UploadCameraScreen(
@@ -137,5 +137,18 @@ private fun takePhoto(
                 Toast.makeText(context, "사진 촬영 실패", Toast.LENGTH_SHORT).show()
             }
         }
+    )
+}
+
+fun Context.createImageUri(): Uri {
+    val file = File.createTempFile(
+        "temp_image",
+        ".jpg",
+        this.externalCacheDir
+    )
+    return FileProvider.getUriForFile(
+        this,
+        "${this.packageName}.fileprovider",
+        file
     )
 }

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadCameraViewModel.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadCameraViewModel.kt
@@ -10,11 +10,9 @@ class CameraViewModel : ViewModel() {
 
     // 다이얼로그 표시 여부
     var showConfirmDialog by mutableStateOf(false)
-        private set
 
     // 찍은 사진의 주소를 저장할 변수 추가
     var capturedUri by mutableStateOf<Uri?>(null)
-        private set
 
     // 사진 촬영 완료 시 호출
     fun onPhotoCaptured(uri: Uri) {

--- a/app/src/main/java/com/solux/moro/ui/mission/MissionCameraScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/mission/MissionCameraScreen.kt
@@ -1,34 +1,126 @@
 package com.solux.moro.ui.mission
 
-
-import androidx.compose.foundation.layout.Box
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
+import androidx.camera.core.CameraSelector
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.solux.moro.ui.camera.CameraLayout
+import com.solux.moro.ui.camera.CameraViewModel
+import java.io.File
 
 @Composable
-fun MissionCameraScreen() {
-    var showDialog by remember { mutableStateOf(false) }
+fun MissionCameraScreen(
+    viewModel: CameraViewModel = viewModel(),
+    onMissionComplete: (Uri) -> Unit = {} // 최종 선택된 사진 1장만
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val previewView = remember { PreviewView(context) }
+    val imageCapture = remember { ImageCapture.Builder().build() }
+
+    // 남은 기회 (3회 시작)
+    var shotsLeft by remember { mutableIntStateOf(3) }
+
+    LaunchedEffect(Unit) {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build()
+            preview.setSurfaceProvider(previewView.surfaceProvider)
+
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(
+                    lifecycleOwner, CameraSelector.DEFAULT_BACK_CAMERA, preview, imageCapture
+                )
+            } catch (e: Exception) {
+                Log.e("Camera", "카메라 연결 실패", e)
+            }
+        }, ContextCompat.getMainExecutor(context))
+    }
 
     CameraLayout(
         showShotCount = true,
-        onCameraClick = { showDialog = true },
-        showConfirmDialog = showDialog,
-        onConfirm = { showDialog = false },
-        onRetry = { showDialog = false },
-        cameraContent = { Box(Modifier.fillMaxSize()) }
+        remainingShots = shotsLeft, // 3 -> 2 -> 1
+
+        showConfirmDialog = viewModel.showConfirmDialog,
+        capturedImageUri = viewModel.capturedUri,
+
+        // 1. 셔터 눌렀을 때
+        onCameraClick = {
+            takeMissionPhoto(context, imageCapture) { uri ->
+                viewModel.capturedUri = uri
+
+                // 마지막 기회(1)였다면? -> 바로 업로드
+                if (shotsLeft == 1) {
+                    onMissionComplete(uri)
+                } else {
+                    // 아직 기회가 남았다면(3, 2) -> 다이얼로그
+                    viewModel.showConfirmDialog = true
+                }
+            }
+        },
+
+        // [예] 눌렀을 때
+        onConfirm = {
+            // 남은 기회 상관없이 바로 미션 완료
+            viewModel.capturedUri?.let { uri ->
+                viewModel.onConfirm() // 다이얼로그 닫기
+                onMissionComplete(uri) // 화면 이동
+            }
+        },
+
+        // 3. [다시 찍기] 눌렀을 때 (기회 차감)
+        onRetry = {
+            // 사진 버림
+            viewModel.onRetry()
+
+            // 기회 1회 차감 (3->2, 2->1)
+            if (shotsLeft > 1) {
+                shotsLeft--
+            }
+            // (참고: shotsLeft가 1일 때는 위에서 바로 통과되므로 여기로 올 일이 없음)
+        },
+
+        cameraContent = {
+            AndroidView({ previewView }, Modifier.fillMaxSize())
+        }
     )
 }
 
+private fun takeMissionPhoto(
+    context: Context,
+    imageCapture: ImageCapture,
+    onSaved: (Uri) -> Unit
+) {
+    val file = File.createTempFile("mission_${System.currentTimeMillis()}", ".jpg", context.externalCacheDir)
+    val options = ImageCapture.OutputFileOptions.Builder(file).build()
 
-@Preview
-@Composable
-fun MissionCameraScreenpreview() {
-    MissionCameraScreen()
+    imageCapture.takePicture(
+        options, ContextCompat.getMainExecutor(context),
+        object : ImageCapture.OnImageSavedCallback {
+            override fun onImageSaved(res: ImageCapture.OutputFileResults) {
+                val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+                onSaved(uri)
+            }
+            override fun onError(e: ImageCaptureException) {
+                Log.e("Camera", "사진 촬영 실패", e)
+            }
+        }
+    )
 }


### PR DESCRIPTION
## 📌연관 이슈
- closed #41 

## 📝작업 내용
- MissionCameraScreen 구현: 총 3번의 촬영 기회 제공 (3 -> 2 -> 1 카운트다운)
- 촬영 로직 적용:
  1. 성공(예) 시 즉시 미션 완료 처리
  2. 실패(다시 찍기) 시 기회 1회 차감 후 재촬영
  3. 마지막 기회(1회 남음)에서는 촬영 후 즉시 강제 완료
- CameraLayout 개선: shotCount(남은 횟수) 표시 UI 추가 및 위치 조정 (TopBar 하단 우측)
- CameraViewModel 수정: 외부 화면에서 상태 제어가 가능하도록 capturedUri, showConfirmDialog의 private set 제거
- UploadCameraScreen 수정: createImageUri 확장 함수 추가로 의존성 문제 해결

## 📷스크린샷
<img width="361" height="799" alt="image" src="https://github.com/user-attachments/assets/195cf0a0-72be-4d89-92a9-f473b70584cb" />
<img width="361" height="795" alt="image" src="https://github.com/user-attachments/assets/3693623c-d6e4-4677-9789-c4bfc3c83d2f" />

  
## 💬리뷰어 요구사항
