### PR TITLE
[feat] 게시물 업로드 동작 구현

### DIFF
--- a/app/src/main/java/com/solux/moro/core/util/FileUtils.kt
+++ b/app/src/main/java/com/solux/moro/core/util/FileUtils.kt
@@ -1,0 +1,36 @@
+package com.solux.moro.core.util
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+
+object FileUtils {
+
+    // Uri > 실제 파일 변환 함수
+    fun uriToFile(context: Context, uri: Uri): File? {
+        try {
+            // 1. ContentResolver를 통해 Uri에서 데이터를 읽어올 통로를 엽니다.
+            val inputStream: InputStream? = context.contentResolver.openInputStream(uri) ?: return null
+            if (inputStream == null) return null
+            // 2. 앱의 임시 캐시 폴더에 빈 파일을 하나 만듭니다. (이름은 현재시간.jpg)
+            val file = File(context.cacheDir, "temp_image_${System.currentTimeMillis()}.jpg")
+
+            // 3. 빈 파일에 데이터를 씁니다.
+            val outputStream = FileOutputStream(file)
+            inputStream.use { input ->
+                outputStream.use { output ->
+                    input.copyTo(output) // 내용 복사
+                }
+            }
+
+            // 4. 완성된 파일을 반환
+            return file
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return null
+        }
+    }
+}

--- a/app/src/main/java/com/solux/moro/ui/camera/Search_Location.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/Search_Location.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -24,11 +25,23 @@ import androidx.compose.ui.unit.sp
 import com.solux.moro.R
 import com.solux.moro.core.util.figmaDp
 
-
+data class PlaceData(
+    val name: String,
+    val address: String
+)
 @Composable
 fun LocationBottomSheet(
-    onClose: () -> Unit
-){
+    onClose: () -> Unit,
+    onPlaceSelected: (String) -> Unit,
+    selectedLocation: String, // [2] 현재 선택된 위치 이름 (체크 표시용)
+    nearbyPlaces: List<PlaceData> = listOf( // [3] 가짜 데이터 (나중에 백엔드 데이터로 교체될 곳)
+        PlaceData("숙명여자대학교", "Seoul, South Korea"),
+        PlaceData("N서울타워", "Seoul, South Korea"),
+        PlaceData("경복궁", "Seoul, South Korea"),
+        PlaceData("북촌한옥마을", "Seoul, South Korea"),
+        PlaceData("명동성당", "Seoul, South Korea")
+    )
+) {
     Column(
         modifier = Modifier
             .shadow(
@@ -232,40 +245,14 @@ fun LocationBottomSheet(
                 verticalArrangement = Arrangement.spacedBy(figmaDp(12f)),
                 contentPadding = PaddingValues(vertical = figmaDp(8f))
             ) {
-                // TODO: 장소 리스트 데이터 연동 후 items()로 변경 예정
-                item {
+                // items()를 사용하여 리스트만큼 반복 생성
+                items(nearbyPlaces) { place ->
                     PlaceItem(
-                        isSelected = true,
-                        name = "Gyeongbokgung Palace",
-                        address = "Seoul, South Korea"
-                    )
-                }
-                item {
-                    PlaceItem(
-                        isSelected = false,
-                        name = "N Seoul Tower",
-                        address = "Seoul, South Korea"
-                    )
-                }
-                item {
-                    PlaceItem(
-                        isSelected = false,
-                        name = "Bukchon Hanok Village",
-                        address = "Seoul, South Korea"
-                    )
-                }
-                item {
-                    PlaceItem(
-                        isSelected = false,
-                        name = "Bukchon Hanok Village",
-                        address = "Seoul, South Korea"
-                    )
-                }
-                item {
-                    PlaceItem(
-                        isSelected = false,
-                        name = "Bukchon Hanok Village",
-                        address = "Seoul, South Korea"
+                        // 현재 이 아이템의 이름이 선택된 이름과 같으면 체크 표시
+                        isSelected = (place.name == selectedLocation),
+                        name = place.name,
+                        address = place.address,
+                        onClick = { onPlaceSelected(place.name) } // 클릭 시 이름 전달
                     )
                 }
             }

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadPostScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadPostScreen.kt
@@ -1,5 +1,6 @@
 package com.solux.moro.ui.camera
 
+import android.net.Uri
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,34 +22,49 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.solux.moro.R
 import com.solux.moro.core.designsystem.component.BottomBar
 import com.solux.moro.core.designsystem.component.top.TopBarBack
 import com.solux.moro.core.util.figmaDp
 import com.solux.moro.ui.mission.InstagramUpload
 import com.solux.moro.ui.mission.Upload_Button
+import com.solux.moro.ui.viewmodel.UploadViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun UploadPostScreen() {
-    var step by remember { mutableStateOf(0) }
-    var selectedColorIndex by remember { mutableStateOf<Int?>(null) }
+fun UploadPostScreen(
+    capturedUri: Uri,
+    viewModel: UploadViewModel = viewModel(),
+    onNavigateHome: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
     var showBottomSheet by remember { mutableStateOf(false) }
+
+    // 진입 시 분석 시작
+    LaunchedEffect(capturedUri) {
+        viewModel.initAnalysis(capturedUri)
+    }
 
     Scaffold(
         topBar = { TopBarBack("게시물 업로드") },
@@ -60,96 +77,101 @@ fun UploadPostScreen() {
                 .fillMaxHeight()
                 .background(color = Color(0xFF121212))
                 .padding(innerPadding)
-                .padding(start = figmaDp(16f), top = figmaDp(70f), end = figmaDp(16f), bottom = figmaDp(70f)),
+                .padding(start = figmaDp(16f), top = figmaDp(70f), end = figmaDp(16f), bottom = figmaDp(30f)),
             verticalArrangement = Arrangement.spacedBy(figmaDp(30f), Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            //컬러 수집 문구
+            // 1. 단계별 멘트
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(figmaDp(28f)),
+                modifier = Modifier.fillMaxWidth().height(figmaDp(28f)),
                 horizontalArrangement = Arrangement.spacedBy(figmaDp(8f), Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                UploadStepTitle(step)
+                UploadStepTitle(state.step)
             }
-            // 위치
+
+            // 2. 위치 (Step 0에서만 클릭 가능하도록 제어)
             Post_Place(
-                onClick = {
-                    showBottomSheet = true
-                }
+                locationName = state.detectedLocation,
+                isClickable = (state.step == 0),
+                showActiveColor = (state.step == 3),
+                onClick = { showBottomSheet = true }
             )
+
+            // 바텀 시트 (위치 변경용)
             if (showBottomSheet) {
                 ModalBottomSheet(
                     onDismissRequest = { showBottomSheet = false },
-                    containerColor = Color.Transparent, // 네 디자인 유지
-                    dragHandle = null                   // 상단 핸들 제거
+                    containerColor = Color.Transparent,
+                    dragHandle = null
                 ) {
-                    LocationBottomSheet(onClose = { showBottomSheet = false })
+                    LocationBottomSheet(
+                        onClose = { showBottomSheet = false },
+                        onPlaceSelected = { newPlace ->
+                            viewModel.updateLocation(newPlace) // 뷰모델에 선택한 장소 알림
+                            showBottomSheet = false
+                        },
+                        selectedLocation = state.detectedLocation // 현재 선택된 장소 이름을 넘겨줌
+                    )
                 }
             }
 
-            // 게시물
+            // 3. 게시물 프레임 (Step 1에서만 색상 선택 가능)
             UploadPostFrame(
-                step = step,
-                selectedColorIndex = selectedColorIndex,
-                onColorSelected = { selectedColorIndex = it }
+                step = state.step,
+                imageUri = state.capturedUri,
+                colors = state.analyzedColors,
+                selectedColorIndex = state.selectedColorIndex,
+                onColorSelected = { viewModel.selectColor(it) }
             )
 
-
-            // 버튼
+            // 4. 하단 버튼 (Step에 따라 '다음' / '업로드' / '완료' 변경)
             Row(
                 horizontalArrangement = Arrangement.spacedBy(figmaDp(8f)),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 UploadBottomAction(
-                    step = step,
-                    onNext = { step++ },
-                    onUpload = { step = 3 },
-                    onInstagram = {
-                        // TODO: 인스타 공유
-                    }
+                    step = state.step,
+                    // Step 1일 때는 색상을 골라야만 '다음' 버튼 활성화
+                    isNextEnabled = if (state.step == 1) state.selectedColorIndex != null else true,
+                    onNext = { viewModel.nextStep() },
+                    onUpload = { viewModel.uploadPost() },
+                    onInstagram = { /* 인스타 로직 */ }
                 )
             }
-
         }
     }
 }
-
 @Composable
 fun UploadStepTitle(step: Int) {
     Text(
         text = when (step) {
-            0 -> "이 사진의 컬러를 수집할까요?"
-            1 -> "대표색상을 선택해주세요."
-            else -> "Moro에 업로드하면 나의 색상 여정이 지도에 그려집니다."
+            0 -> "이 사진의 컬러를 수집할까요?"     // Step 0: 위치 확인 단계
+            1 -> "대표색상을 선택해주세요."       // Step 1: 색상 선택 단계
+            2 -> "Moro에 업로드하면 나의 색상 여정이 지도에 그려집니다." // Step 2: 업로드 준비
+            else -> "업로드가 완료되었습니다!"    // Step 3: 완료
         },
         style = when (step) {
             2 -> TextStyle(
                 fontSize = 14.sp,
-                lineHeight = 19.6.sp,
-                //fontFamily = FontFamily(Font(R.font.inter)),
                 fontWeight = FontWeight(600),
                 color = Color(0xFFBDBDBD),
                 textAlign = TextAlign.Center,
             )
-
             else -> TextStyle(
                 fontSize = 18.sp,
-                lineHeight = 28.sp,
                 fontWeight = FontWeight(400),
                 color = Color.White,
                 textAlign = TextAlign.Center,
             )
         }
     )
-
 }
 
 @Composable
 fun UploadBottomAction(
     step: Int,
+    isNextEnabled: Boolean = true,
     onNext: () -> Unit,
     onUpload: () -> Unit,
     onInstagram: () -> Unit
@@ -164,11 +186,14 @@ fun UploadBottomAction(
 
 
         2 -> {
-            Upload_Button()
+            Upload_Button(onClick = onUpload)
         }
 
         3 -> {
-            InstagramUpload()
+            InstagramUpload(
+                onInstagramClick = onInstagram,
+                onSaveClick = { /* 나중에 저장 기능 구현하면 여기에 연결 */ }
+            )
         }
     }
 }
@@ -205,41 +230,42 @@ fun Next_Button(
 }
 
 @Composable
-fun Post_Place(onClick: () -> Unit) {
+fun Post_Place(
+    locationName: String,
+    showActiveColor: Boolean = false,
+    isClickable: Boolean, // 클릭 가능 여부 파라미터 추가
+    onClick: () -> Unit
+) {
+    // 클릭이 가능하거나(Step 0) OR 활성화 색상을 보여달라고 하면(Step 3) -> 흰색
+    // 그 외에는 -> 회색
+    val textColor = if (isClickable || showActiveColor) Color.White else Color.Gray
+    val iconAlpha = if (isClickable || showActiveColor) 1f else 0.4f
+
     Row(
-        modifier = Modifier .clickable { onClick() },
+        modifier = Modifier
+            .clickable(enabled = isClickable) { onClick() }, // Step 0 아니면 클릭 불가
         horizontalArrangement = Arrangement.spacedBy(figmaDp(10f), Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
-            modifier = Modifier
-                .width(figmaDp(16.36364f))
-                .height(figmaDp(20f)),
+            modifier = Modifier.width(figmaDp(16.36f)).height(figmaDp(20f)),
             painter = painterResource(id = R.drawable.map),
-            contentDescription = "image description"
+            contentDescription = "map",
+            alpha = iconAlpha
         )
         Text(
-            text = "숙명여자대학교 Sookmyung women",
+            text = locationName,
             style = TextStyle(
                 fontSize = 18.sp,
-                lineHeight = 28.sp,
-                //fontFamily = FontFamily(Font(R.font.inter)),
                 fontWeight = FontWeight(400),
-                color = Color(0xFFFFFFFF),
+                color = textColor, // 상태에 따라 색상 변경
                 textAlign = TextAlign.Center,
             )
         )
-
-        Row(
-            modifier = Modifier
-                .width(figmaDp(9.14158f))
-                .height(figmaDp(16f)),
-            horizontalArrangement = Arrangement.spacedBy(figmaDp(10.445481300354004f), Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+        if (isClickable) { // 수정 가능할 때만 화살표 보이기
             Image(
                 painter = painterResource(id = R.drawable.chevron_right),
-                contentDescription = "image description",
+                contentDescription = "edit",
             )
         }
     }
@@ -298,41 +324,41 @@ fun UploadPost_Color(
 @Composable
 fun UploadPostFrame(
     step: Int,
+    imageUri: Uri?,
+    colors: List<Pair<String, String>>,
     selectedColorIndex: Int?,
     onColorSelected: (Int) -> Unit
 ) {
-    val colors = listOf(
-        "#3357FF" to "42%",
-        "#FF5733" to "28%",
-        "#33FF57" to "18%",
-        "#F3FF33" to "12%"
-    )
-
     Row(
         modifier = Modifier
-            .border(
-                width = figmaDp(1f),
-                color = Color(0xFFA5A5A5),
-                shape = RoundedCornerShape(figmaDp(18.3f))
-            )
+            .border(width = figmaDp(1f), color = Color(0xFFA5A5A5), shape = RoundedCornerShape(figmaDp(18.3f)))
             .width(figmaDp(343f))
             .height(figmaDp(342.7f))
             .padding(figmaDp(14f)),
         horizontalArrangement = Arrangement.spacedBy(figmaDp(7.3f)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-
+        // 사진 (왼쪽)
         Box(
             modifier = Modifier
                 .width(figmaDp(235f))
                 .height(figmaDp(313f))
                 .background(Color.DarkGray, RoundedCornerShape(figmaDp(9.14f)))
-        )
+                .clip(RoundedCornerShape(figmaDp(9.14f)))
+        ) {
+            if (imageUri != null) {
+                AsyncImage(
+                    model = imageUri,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
 
+        // 색상 리스트 (오른쪽)
         Column(
-            modifier = Modifier
-                .width(figmaDp(71.32f))
-                .height(figmaDp(313.46f)),
+            modifier = Modifier.width(figmaDp(71.32f)).height(figmaDp(313.46f)),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             colors.forEachIndexed { index, (hex, percent) ->
@@ -340,18 +366,10 @@ fun UploadPostFrame(
                     colorHex = hex,
                     percent = percent,
                     isSelected = selectedColorIndex == index,
-                    isSelectable = step == 1,
+                    isSelectable = (step == 1), // Step 1에서만 선택 가능!
                     onClick = { onColorSelected(index) }
                 )
-
             }
         }
     }
-}
-
-
-@Preview
-@Composable
-fun UploadPreview() {
-    UploadPostScreen()
 }

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadViewModel.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadViewModel.kt
@@ -1,0 +1,82 @@
+package com.solux.moro.ui.viewmodel
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// 상태 관리를 위한 데이터 클래스
+data class UploadState(
+    val step: Int = 0, // 0:위치확인, 1:색상선택, 2:업로드준비, 3:완료
+    val capturedUri: Uri? = null,
+    val detectedLocation: String = "위치 정보 분석 중...",
+    val analyzedColors: List<Pair<String, String>> = emptyList(), // (Hex, 퍼센트)
+    val selectedColorIndex: Int? = null, // 사용자가 선택한 대표 색상 인덱스
+    val isUploading: Boolean = false
+)
+
+class UploadViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(UploadState())
+    val uiState = _uiState.asStateFlow()
+
+    // 화면 진입 시 초기 분석 (자동으로 4가지 색과 위치 뜸)
+    fun initAnalysis(uri: Uri) {
+        if (_uiState.value.capturedUri == uri) return
+        _uiState.value = _uiState.value.copy(capturedUri = uri)
+
+        viewModelScope.launch {
+            // TODO: 실제 서버/Location 로직 들어갈 곳
+            delay(1000) // 분석 시간 시뮬레이션
+
+            _uiState.value = _uiState.value.copy(
+                detectedLocation = "서울시 마포구 (자동 감지)",
+                analyzedColors = listOf(
+                    "#3357FF" to "42%",
+                    "#FF5733" to "28%",
+                    "#33FF57" to "18%",
+                    "#F3FF33" to "12%"
+                )
+            )
+        }
+    }
+
+    // Step 0: 위치 변경 (바텀시트에서 선택 시)
+    fun updateLocation(newLocation: String) {
+        _uiState.value = _uiState.value.copy(detectedLocation = newLocation)
+    }
+
+    // Step 1: 색상 선택
+    fun selectColor(index: Int) {
+        _uiState.value = _uiState.value.copy(selectedColorIndex = index)
+    }
+
+    // [다음] 버튼 클릭 로직
+    fun nextStep() {
+        val current = _uiState.value
+        when (current.step) {
+            0 -> {
+                // 위치 확인 완료 -> 색상 선택 단계로 이동
+                _uiState.value = current.copy(step = 1)
+            }
+            1 -> {
+                // 색상 선택 완료 -> 업로드 준비 단계로 이동
+                if (current.selectedColorIndex != null) {
+                    _uiState.value = current.copy(step = 2)
+                }
+            }
+        }
+    }
+
+    // Step 2 -> 3: 업로드 수행
+    fun uploadPost() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isUploading = true)
+            // TODO: 실제 업로드 통신
+            delay(2000)
+            _uiState.value = _uiState.value.copy(isUploading = false, step = 3)
+        }
+    }
+}

--- a/app/src/main/java/com/solux/moro/ui/mission/MissionUploadScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/mission/MissionUploadScreen.kt
@@ -3,6 +3,7 @@ package com.solux.moro.ui.mission
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -148,7 +149,9 @@ fun Upload_Section() {
 }
 
 @Composable
-fun Upload_Button() {
+fun Upload_Button(
+    onClick: () -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -157,6 +160,7 @@ fun Upload_Button() {
                 color = Color(0xFFF2F2F2),
                 shape = RoundedCornerShape(figmaDp(12f))
             )
+            .clickable { onClick() }
             .padding(
                 start = figmaDp(16f),
                 top = figmaDp(16f),
@@ -210,7 +214,10 @@ fun Upload_Button() {
 }
 
 @Composable
-fun InstagramUpload(){
+fun InstagramUpload(
+    onInstagramClick: () -> Unit = {}, // 인스타 클릭 이벤트
+    onSaveClick: () -> Unit = {}       // 저장 클릭 이벤트
+){
     Row(
         modifier = Modifier
             .width(figmaDp(138f))
@@ -220,6 +227,7 @@ fun InstagramUpload(){
     ) {
         //인스타
         Column(
+            modifier = Modifier.clickable { onInstagramClick() },
             verticalArrangement = Arrangement.spacedBy(figmaDp(4f), Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -249,6 +257,7 @@ fun InstagramUpload(){
 
         //저장
         Column(
+            modifier = Modifier.clickable { onSaveClick() },
             verticalArrangement = Arrangement.spacedBy(figmaDp(4f), Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {


### PR DESCRIPTION
## 📌연관 이슈
- closed #43 

## 📝작업 내용
1. 게시물 업로드 프로세스 구현 (UploadPostScreen)
- 4단계 상태 로직 적용: 장소 확인 → 대표색상 선택 → 업로드 대기 → 완료로 이어지는 단계별 UI 전환 흐름을 구축
- 장소 선택 바텀시트 연동: LocationBottomSheet를 통해 실시간으로 선택된 장소가 화면에 반영되도록 로직을 연결


2. 유틸리티 및 기반 작업 (FileUtils.kt)
- 파일 변환 유틸리티 추가: 서버 전송을 위해 Uri 데이터를 실제 File 객체로 변환하는 로직을 FileUtils에 구현
3. 버튼 수정
- 업로드 + 인스타/저장 버튼 클릭 추가
  
4.  추가로 할일
- 1. 현재 위치(GPS) 권한 요청 및 좌표 가져오기
- 2. 구글 맵 API(또는 다른 지도 API) 연동하여 주변 장소 검색
- 3. 바텀 시트에 실제 데이터 주입하기
## 💬리뷰어 요구사항
