### PR TITLE
[feat] 메뉴 화면 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Morofrontend">
+        android:theme="@style/Theme.Morofrontend"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
@@ -44,6 +46,7 @@
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/solux/moro/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/solux/moro/core/navigation/NavGraph.kt
@@ -10,6 +10,8 @@ import com.solux.moro.ui.followlist.FollowRequestScreen
 import com.solux.moro.ui.followlist.FollowRequestViewModel
 import com.solux.moro.ui.followlist.FollowingViewModel
 import com.solux.moro.ui.home.HomeScreen
+import com.solux.moro.ui.menu.ColorMapScreen
+import com.solux.moro.ui.menu.MenuScreen
 import com.solux.moro.ui.notification.NotificationScreen
 import com.solux.moro.ui.notification.NotificationViewModel
 import com.solux.moro.ui.paletteedit.PaletteEditScreen
@@ -25,6 +27,12 @@ fun NavGraph(navController: NavHostController){
     NavHost(navController = navController, startDestination ="profile_test") {
         composable("home") { //홈 화면
             HomeScreen()
+        }
+        composable("menu") {
+            MenuScreen(navController = navController)
+        }
+        composable("colormap") {
+            ColorMapScreen(navController = navController)
         }
         composable("profile_test") {
             val viewModel: ProfileViewModel = hiltViewModel()

--- a/app/src/main/java/com/solux/moro/data/dto/request/SettingRequestDto.kt
+++ b/app/src/main/java/com/solux/moro/data/dto/request/SettingRequestDto.kt
@@ -1,0 +1,12 @@
+package com.solux.moro.data.dto.request
+
+
+// 비공개/공개 설정 변경용
+data class PrivacyRequestDto(
+    val isPublic: Boolean
+)
+
+// 푸시 알림 설정 변경용
+data class NotificationRequestDto(
+    val isNotification: Boolean
+)

--- a/app/src/main/java/com/solux/moro/data/repository/menurepo/MenuNetworkModule.kt
+++ b/app/src/main/java/com/solux/moro/data/repository/menurepo/MenuNetworkModule.kt
@@ -1,0 +1,32 @@
+package com.solux.moro.data.repository.menurepo
+
+import com.solux.moro.data.service.SettingService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MenuNetworkModule {
+
+    @Provides
+    @Singleton
+    @Named("MenuRetrofit")
+    fun provideMenuRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("http://moro-be.store") // Swagger 서버 주소
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideSettingService(@Named("MenuRetrofit") retrofit: Retrofit): SettingService {
+        return retrofit.create(SettingService::class.java)
+    }
+}

--- a/app/src/main/java/com/solux/moro/data/repository/menurepo/MenuRepositoryModule.kt
+++ b/app/src/main/java/com/solux/moro/data/repository/menurepo/MenuRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.solux.moro.data.repository.menurepo
+
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MenuRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSettingRepository(
+        settingRepositoryImpl: SettingRepositoryImpl
+    ): SettingRepository
+}

--- a/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingPreferenceManager.kt
+++ b/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingPreferenceManager.kt
@@ -1,0 +1,36 @@
+package com.solux.moro.data.repository.menurepo
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingPreferenceManager @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs = context.getSharedPreferences("moro_settings", Context.MODE_PRIVATE)
+
+    // 공개 설정 저장/불러오기
+    fun setVisibility(isVisible: Boolean) {
+        prefs.edit().putBoolean("is_visible", isVisible).apply()
+    }
+
+    fun getVisibility(): Boolean {
+        return prefs.getBoolean("is_visible", false) // 기본값 false
+    }
+
+    // 알림 설정 저장/불러오기
+    fun setNotification(isEnabled: Boolean) {
+        prefs.edit().putBoolean("is_noti_enabled", isEnabled).apply()
+    }
+
+    fun getNotification(): Boolean {
+        return prefs.getBoolean("is_noti_enabled", false) // 기본값 false
+    }
+
+    fun clearAuthData() {
+        prefs.edit().remove("access_token").apply()
+        prefs.edit().remove("is_visible").remove("is_noti_enabled").apply()
+    }
+}

--- a/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingRepository.kt
+++ b/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingRepository.kt
@@ -1,0 +1,18 @@
+package com.solux.moro.data.repository.menurepo
+
+import kotlinx.coroutines.flow.Flow
+
+interface SettingRepository {
+    // 로그아웃
+    suspend fun logout(): Result<Unit>
+
+    // 공개 설정
+    suspend fun updateVisibility(visible: Boolean): Result<Unit>
+
+    // 현재 공개 설정 상태를
+    fun getVisibility(): Flow<Boolean>
+
+
+    // 알림
+    suspend fun updateNotification(enabled: Boolean): Result<Unit>
+}

--- a/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingRepositoryImpl.kt
+++ b/app/src/main/java/com/solux/moro/data/repository/menurepo/SettingRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package com.solux.moro.data.repository.menurepo
+
+import com.solux.moro.data.dto.request.NotificationRequestDto
+import com.solux.moro.data.dto.request.PrivacyRequestDto
+import com.solux.moro.data.service.SettingService
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class SettingRepositoryImpl @Inject constructor(
+    private val settingService: SettingService
+) : SettingRepository {
+
+    // Swagger에서 복사한 토큰
+    private val ACCESS_TOKEN = ""
+
+    override suspend fun logout(): Result<Unit> {
+        return try {
+            val response = settingService.logout(ACCESS_TOKEN)
+            if (response.isSuccessful) Result.success(Unit)
+            else Result.failure(Exception("로그아웃 실패"))
+        } catch (e: Exception) { Result.failure(e) }
+    }
+
+    override suspend fun updateVisibility(visible: Boolean): Result<Unit> {
+        return try {
+            val response = settingService.updatePrivacy(ACCESS_TOKEN, PrivacyRequestDto(visible))
+            if (response.isSuccessful) Result.success(Unit)
+            else Result.failure(Exception("공개 설정 변경 실패"))
+        } catch (e: Exception) { Result.failure(e) }
+    }
+
+    // 알림 설정 기능
+    override suspend fun updateNotification(enabled: Boolean): Result<Unit> {
+        return try {
+            val response = settingService.updateNotification(
+                token = ACCESS_TOKEN,
+                body = NotificationRequestDto(isNotification = enabled)
+            )
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception("알림 설정 실패"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override fun getVisibility(): Flow<Boolean> = flowOf(true)
+}

--- a/app/src/main/java/com/solux/moro/data/service/SettingService.kt
+++ b/app/src/main/java/com/solux/moro/data/service/SettingService.kt
@@ -1,0 +1,31 @@
+package com.solux.moro.data.service
+
+import com.solux.moro.data.dto.request.NotificationRequestDto
+import com.solux.moro.data.dto.request.PrivacyRequestDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+
+interface SettingService {
+    // 공개/비공개 설정
+    @PATCH("/api/settings/privacy")
+    suspend fun updatePrivacy(
+        @Header("Authorization") token: String,
+        @Body body: PrivacyRequestDto
+    ): Response<Unit>
+
+    // 알림 설정
+    @PATCH("/api/settings/notification")
+    suspend fun updateNotification(
+        @Header("Authorization") token: String,
+        @Body body: NotificationRequestDto
+    ): Response<Unit>
+
+    // 로그아웃
+    @POST("/api/auth/logout")
+    suspend fun logout(
+        @Header("Authorization") token: String
+    ): Response<Unit>
+}

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadCameraScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadCameraScreen.kt
@@ -28,7 +28,7 @@ import java.io.File
 
 @Composable
 fun UploadCameraScreen(
-    viewModel: CameraViewModel = viewModel()
+    viewModel: UploadCameraViewModel = viewModel()
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/app/src/main/java/com/solux/moro/ui/camera/UploadCameraViewModel.kt
+++ b/app/src/main/java/com/solux/moro/ui/camera/UploadCameraViewModel.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
-class CameraViewModel : ViewModel() {
+class UploadCameraViewModel : ViewModel() {
 
     // 다이얼로그 표시 여부
     var showConfirmDialog by mutableStateOf(false)

--- a/app/src/main/java/com/solux/moro/ui/menu/ColorMapScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/menu/ColorMapScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavHostController
 import com.solux.moro.core.util.figmaDp
 
 
@@ -53,7 +54,7 @@ data class ColorItem(
 typealias ColorGrid = List<List<ColorItem>>
 
 @Composable
-fun ColorMapScreen() {
+fun ColorMapScreen(navController: NavHostController) {
     var isNumberOn by remember { mutableStateOf(true) }
     var currentTheme by remember {
         mutableStateOf(ColorThemeType.PASTEL)
@@ -596,8 +597,4 @@ fun ColorCell(
 
 
 
-@Preview
-@Composable
-fun ColorMapScreenPreview() {
-    ColorMapScreen()
-}
+

--- a/app/src/main/java/com/solux/moro/ui/menu/MenuScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/menu/MenuScreen.kt
@@ -3,26 +3,13 @@ package com.solux.moro.ui.menu
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,52 +17,90 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavHostController
 import com.solux.moro.core.designsystem.component.BottomBar
 import com.solux.moro.core.designsystem.component.top.TopBarBack
-import androidx.compose.ui.text.TextStyle
 import com.solux.moro.core.util.figmaDp
 
 @Composable
-fun MenuScreen() {
-    var isPublic by remember { mutableStateOf(true) }
-    var isPushOn by remember { mutableStateOf(false) }
+fun MenuScreen(
+    viewModel: MenuViewModel = hiltViewModel(),
+    navController: NavHostController
+) {
+    // UI 상태 관리
+    val isPublic by viewModel.isPublic.collectAsState()
+    val isPushOn by viewModel.isNotificationEnabled.collectAsState()
 
+    var showLogoutDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = { TopBarBack("메뉴") },
         bottomBar = { BottomBar() }
     ) { innerPadding ->
-
-        LazyColumn(
-            modifier = Modifier
-                .background(Color(0xFF121212))
-                .padding(innerPadding)
-                .fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(figmaDp(14f)),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            item {
-                Settings()
+        Box(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier
+                    .background(Color(0xFF121212))
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(figmaDp(14f)),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                item {
+                    SettingsSection(navController = navController)
+                }
+                item {
+                    SettingOptions(
+                        isPublic = isPublic,
+                        onPublicToggle = {
+                            viewModel.onVisibilityChanged(it)
+                        },
+                        isPushOn = isPushOn,
+                        onPushToggle = {
+                            viewModel.onPushSettingsChanged(it)
+                        },
+                        onLogoutClick = {
+                            showLogoutDialog = true
+                        }
+                    )
+                }
             }
-            item {
-                Setting_3(
-                    isPublic = isPublic,
-                    onPublicToggle = { isPublic = it },
-                    isPushOn = isPushOn,
-                    onPushToggle = { isPushOn = it }
-                )
 
+            // 로그아웃 다이얼로그 (상태가 true일 때만 표시)
+            if (showLogoutDialog) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.6f))
+                        .clickable { showLogoutDialog = false },
+                    contentAlignment = Alignment.Center
+                ) {
+                    LogoutDialog(
+                        onDismiss = { showLogoutDialog = false },
+                        onConfirm = {
+                            viewModel.performLogout {
+                                showLogoutDialog = false
+
+                                // Splash 화면으로 이동
+                                navController.navigate("splash") {
+                                    popUpTo("menu") { inclusive = true }
+                                }
+                            }
+                        }
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun Settings(
-)
-{
+fun SettingsSection(navController: NavHostController) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -88,26 +113,16 @@ fun Settings(
         verticalArrangement = Arrangement.spacedBy(figmaDp(12f), Alignment.Top),
         horizontalAlignment = Alignment.Start,
     ) {
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(figmaDp(28f)),
-            horizontalArrangement = Arrangement.spacedBy(figmaDp(8f), Alignment.Start),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "설정",
-                style = TextStyle(
-                    fontSize = 20.sp,
-                    lineHeight = 28.sp,
-                    //fontFamily = FontFamily(Font(R.font.inter)),
-                    fontWeight = FontWeight(600),
-                    color = Color(0xFFFFFFFF),
-                )
+        Text(
+            text = "설정",
+            style = TextStyle(
+                fontSize = 20.sp,
+                lineHeight = 28.sp,
+                fontWeight = FontWeight(600),
+                color = Color(0xFFFFFFFF),
             )
-        }
-        Column(
+        )
+        Box(
             modifier = Modifier
                 .border(
                     width = figmaDp(1f),
@@ -120,62 +135,35 @@ fun Settings(
                     color = Color(0xFF171717),
                     shape = RoundedCornerShape(size = figmaDp(16f))
                 )
-                .padding(
-                    start = figmaDp(20f),
-                    top = figmaDp(20f),
-                    end = figmaDp(20f),
-                    bottom = figmaDp(20f)
-                ),
-            verticalArrangement = Arrangement.spacedBy(figmaDp(8f), Alignment.Top),
-            horizontalAlignment = Alignment.Start,
+                .padding(figmaDp(20f))
+                .clickable { navController.navigate("colormap") },
+            contentAlignment = Alignment.CenterStart
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(figmaDp(40f)),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier
-                        .width(figmaDp(263f))
-                        .height(figmaDp(24f)),
-                    horizontalArrangement = Arrangement.spacedBy(figmaDp(8f), Alignment.Start),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        modifier = Modifier
-                            .width(figmaDp(89f))
-                            .height(figmaDp(24f)),
-                        text = "colormap",
-                        style = TextStyle(
-                            fontSize = 20.sp,
-                            lineHeight = 24.sp,
-                            //fontFamily = FontFamily(Font(R.font.inter)),
-                            fontWeight = FontWeight(400),
-                            color = Color(0xFFFFFFFF),
-                        )
+                Text(
+                    text = "colormap",
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight(400),
+                        color = Color(0xFFFFFFFF),
                     )
-                }
-                Row(
+                )
+                Box(
                     modifier = Modifier
                         .size(figmaDp(40f))
                         .background(
                             color = Color(0xFF464646),
                             shape = RoundedCornerShape(size = figmaDp(8f))
                         )
-                        .padding(
-                            start = figmaDp(4f),
-                            top = figmaDp(4f),
-                            end = figmaDp(4f),
-                            bottom = figmaDp(4f)
-                        ),
-                    horizontalArrangement = Arrangement.spacedBy(figmaDp(8f), Alignment.Start),
-                    verticalAlignment = Alignment.CenterVertically,
+                        .padding(figmaDp(4f))
                 ) {
                     Box(
                         modifier = Modifier
-                            .size(figmaDp(32f))
+                            .fillMaxSize()
                             .clip(RoundedCornerShape(figmaDp(4f)))
                             .background(
                                 brush = Brush.linearGradient(
@@ -184,29 +172,24 @@ fun Settings(
                                         Color(0xFFFFBC4F),
                                         Color(0xFFDEFF9C),
                                         Color(0xFFCAFFC6)
-                                    ),
-                                    start = Offset.Zero,
-                                    end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                                    )
                                 )
                             )
                     )
-
                 }
             }
         }
     }
-
 }
 
-
 @Composable
-fun Setting_3(
+fun SettingOptions(
     isPublic: Boolean,
     onPublicToggle: (Boolean) -> Unit,
     isPushOn: Boolean,
-    onPushToggle: (Boolean) -> Unit
-)
- {
+    onPushToggle: (Boolean) -> Unit,
+    onLogoutClick: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -214,6 +197,7 @@ fun Setting_3(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start
     ) {
+        // 공개/비공개 설정
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -222,18 +206,11 @@ fun Setting_3(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = "공개 / 비공개 설정",
-                fontSize = 16.sp,
-                color = Color(0xFFF2F2F2)
-            )
-
-            ToggleButton(
-                isOn = isPublic,
-                onToggle = onPublicToggle
-            )
+            Text(text = "공개 / 비공개 설정", fontSize = 16.sp, color = Color(0xFFF2F2F2))
+            ToggleButton(isOn = isPublic, onToggle = onPublicToggle)
         }
 
+        // 푸시 알림 설정
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -242,45 +219,86 @@ fun Setting_3(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = "푸시 알림 설정",
-                fontSize = 16.sp,
-                color = Color(0xFFF2F2F2)
-            )
-
-            ToggleButton(
-                isOn = isPushOn,
-                onToggle = onPushToggle
-            )
+            Text(text = "푸시 알림 설정", fontSize = 16.sp, color = Color(0xFFF2F2F2))
+            ToggleButton(isOn = isPushOn, onToggle = onPushToggle)
         }
 
+        Spacer(modifier = Modifier.height(figmaDp(16f)))
 
-
+        // 로그아웃 버튼
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(figmaDp(48f))
+                .clickable { onLogoutClick() },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "로그아웃",
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight(400),
+                    color = Color(0xFFA5A5A5),
+                )
+            )
+        }
     }
-    Row(
+}
+
+@Composable
+fun LogoutDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                start = figmaDp(16f),
-                top = figmaDp(16f),
-                end = figmaDp(16f),
-                bottom = figmaDp(16f)
-            ),
-        horizontalArrangement = Arrangement.spacedBy(figmaDp(6f), Alignment.Start),
-        verticalAlignment = Alignment.CenterVertically,
+            .width(figmaDp(280f))
+            .background(
+                color = Color(0xFF121212),
+                shape = RoundedCornerShape(size = figmaDp(24.72f))
+            )
+            .border(1.dp, Color.Gray, RoundedCornerShape(size = figmaDp(24.72f)))
+            .padding(figmaDp(24f)),
+        verticalArrangement = Arrangement.spacedBy(figmaDp(24f)),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "로그아웃",
-
-            // Body1/Regular/16px
+            text = "로그아웃 하시겠습니까?",
             style = TextStyle(
-                fontSize = 16.sp,
-                lineHeight = 22.4.sp,
-                //fontFamily = FontFamily(Font(R.font.inter)),
-                fontWeight = FontWeight(400),
-                color = Color(0xFFA5A5A5),
+                fontSize = 18.sp,
+                fontWeight = FontWeight(600),
+                color = Color.White,
+                textAlign = TextAlign.Center,
             )
         )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(figmaDp(12f))
+        ) {
+            // 취소 버튼
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(figmaDp(44f))
+                    .background(Color(0xFFF2F2F2), RoundedCornerShape(figmaDp(12f)))
+                    .clickable { onDismiss() },
+                contentAlignment = Alignment.Center
+            ) {
+                Text("취소", color = Color.Black, fontWeight = FontWeight.Bold)
+            }
+            // 확인 버튼
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(figmaDp(44f))
+                    .border(1.dp, Color(0xFFA5A5A5), RoundedCornerShape(figmaDp(12f)))
+                    .clickable { onConfirm() },
+                contentAlignment = Alignment.Center
+            ) {
+                Text("확인", color = Color.White, fontWeight = FontWeight.Bold)
+            }
+        }
     }
 }
 
@@ -293,34 +311,19 @@ fun ToggleButton(
         modifier = Modifier
             .width(figmaDp(48f))
             .height(figmaDp(24f))
-            .clip(RoundedCornerShape(figmaDp(9999f)))
-            .background(
-                color = if (isOn) Color(0xFFF2F2F2) else Color(0xFF737373)
-            )
+            .clip(RoundedCornerShape(figmaDp(999f)))
+            .background(color = if (isOn) Color(0xFFF2F2F2) else Color(0xFF737373))
             .clickable { onToggle(!isOn) }
             .padding(figmaDp(2f)),
-        horizontalArrangement = if (isOn)
-            Arrangement.Start else Arrangement.End,
+        horizontalArrangement = if (isOn) Arrangement.End else Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
             modifier = Modifier
                 .size(figmaDp(20f))
                 .clip(CircleShape)
-                .background(
-                    color = if (isOn) Color(0xFFBDBDBD) else Color.White
-                )
-                .border(
-                    width = figmaDp(2f),
-                    color = Color(0xFFF2F2F2),
-                    shape = CircleShape
-                )
+                .background(color = if (isOn) Color(0xFFBDBDBD) else Color.White)
+
         )
     }
-}
-
-@Preview
-@Composable
-fun MenuScreenPreview() {
-    MenuScreen()
 }

--- a/app/src/main/java/com/solux/moro/ui/menu/MenuViewModel.kt
+++ b/app/src/main/java/com/solux/moro/ui/menu/MenuViewModel.kt
@@ -1,0 +1,64 @@
+package com.solux.moro.ui.menu
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.solux.moro.data.repository.menurepo.SettingPreferenceManager
+import com.solux.moro.data.repository.menurepo.SettingRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MenuViewModel @Inject constructor(
+    private val settingRepository: SettingRepository,
+    private val preferenceManager: SettingPreferenceManager
+) : ViewModel() {
+
+    private val _isPublic = MutableStateFlow(preferenceManager.getVisibility())
+    val isPublic = _isPublic.asStateFlow()
+
+    private val _isNotificationEnabled = MutableStateFlow(preferenceManager.getNotification())
+    val isNotificationEnabled = _isNotificationEnabled.asStateFlow()
+
+    // 1. 공개/비공개 설정 변경
+    fun onVisibilityChanged(isVisible: Boolean) {
+        viewModelScope.launch {
+            val result = settingRepository.updateVisibility(isVisible)
+            if (result.isSuccess) {
+                preferenceManager.setVisibility(isVisible)
+                _isPublic.value = isVisible
+                println("로그: 서버/로컬 공개 설정 저장 성공 -> $isVisible")
+            }
+        }
+    }
+
+    // 2. 알림 설정 변경
+    fun onPushSettingsChanged(isEnabled: Boolean) {
+        viewModelScope.launch {
+            val result = settingRepository.updateNotification(isEnabled)
+            if (result.isSuccess) {
+                preferenceManager.setNotification(isEnabled)
+                _isNotificationEnabled.value = isEnabled
+                println("로그: 서버/로컬 알림 설정 저장 성공 -> $isEnabled")
+            }
+        }
+    }
+
+    // 3. 로그아웃 실행
+    fun performLogout(onLogoutSuccess: () -> Unit) {
+        viewModelScope.launch {
+            val result = settingRepository.logout()
+            if (result.isSuccess) {
+                //서버 로그아웃 성공 시 저장된 토큰과 설정 데이터 삭제
+                preferenceManager.clearAuthData()
+
+                println("로그: 서버 로그아웃 완료 및 로컬 토큰 삭제 성공")
+                onLogoutSuccess()
+            } else {
+                println("로그: 로그아웃 실패 -> ${result.exceptionOrNull()}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/solux/moro/ui/mission/MissionCameraScreen.kt
+++ b/app/src/main/java/com/solux/moro/ui/mission/MissionCameraScreen.kt
@@ -19,12 +19,12 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.solux.moro.ui.camera.CameraLayout
-import com.solux.moro.ui.camera.CameraViewModel
+import com.solux.moro.ui.camera.UploadCameraViewModel
 import java.io.File
 
 @Composable
 fun MissionCameraScreen(
-    viewModel: CameraViewModel = viewModel(),
+    viewModel: UploadCameraViewModel = viewModel(),
     onMissionComplete: (Uri) -> Unit = {} // 최종 선택된 사진 1장만
 ) {
     val context = LocalContext.current

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">moro-be.store</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## 📌연관 이슈
- closed #46 

## 📝작업 내용
- 주요 작업 내용

1. 네트워크 보안 정책 설정 network_security_config.xml을 생성하여 특정 도메인(moro-be.store)에 대한 통신 허용 설정
2. 서버 API 연동 (PATCH)
Retrofit을 사용하여 설정 변경 사항을 서버 DB에 즉시 반영하는 로직 구현 ( 푸시 알림 설정 / 공개비공개 설정)

3. 데이터 영속성(Persistence) 관리
SharedPreferences 기반의 로컬 저장소를 추가
앱 실행 시 로컬에 저장된 마지막 상태를 불러와 UI와 동기화

4. UI 상태 관리 및 네비게이션
로그아웃 클릭 시 다이얼로그 노출 ( 로그아웃 api 연결 + 스플래시 화면으로 이동하는 네비게이션 흐름을 구현할 예정 )

> 실제 로그인 기능 대신 고정된 토큰 값을 사용하여 PATCH 및 로그아웃 API 호출 테스트 진행함

## 📷스크린샷
  
<img width="883" height="113" alt="image" src="https://github.com/user-attachments/assets/c670c3d2-46a6-483e-9758-75940862ad36" />

## 💬리뷰어 요구사항
